### PR TITLE
Remove unused strings marked notranslate

### DIFF
--- a/martus-android/res/values/strings.xml
+++ b/martus-android/res/values/strings.xml
@@ -262,7 +262,6 @@
     <string name="swipe_buttons_instructions">You are at the start of %s. Swipe the screen as shown below or tap the arrow buttons to go backward and forward.</string>
 
     <!-- odk - may be used -->
-    <string name="activity_not_found">No activity found to handle: %s</string>
     <string name="add_another">Add Group</string>
     <string name="add_another_repeat">Add another \"%s\" group?</string>
     <string name="add_repeat">Add a new \"%s\" group?</string>
@@ -281,9 +280,7 @@
     <string name="clear_answer">Remove response</string>
     <string name="clear_answer_ask">Remove This Response?</string>
     <string name="clear_answer_no">Cancel</string>
-    <string name="data_saved_error">Sorry, form save failed!</string>
     <string name="data_saved_ok">Form successfully saved!</string>
-    <string name="default_completed">Default to finalized</string>
     <string name="delete_repeat">Remove group</string>
     <string name="delete_repeat_ask">Remove This Group?</string>
     <string name="delete_repeat_confirm">Remove group \"%s\" and all of its sub-groups?</string>
@@ -298,7 +295,6 @@
     <string name="error_occured">Error Occurred</string>
     <string name="file_invalid">File: %s is invalid.</string>
     <string name="file_missing">File: %s is missing.</string>
-    <string name="finished_disk_scan">Finished scanning. All forms loaded.</string>
     <string name="get_barcode">Get Barcode</string>
     <string name="get_forms">Get Blank Form</string>
     <string name="invalid_answer_error">Sorry, this response is invalid!</string>
@@ -312,7 +308,6 @@
     <string name="mark_finished">Mark form as finalized</string>
     <string name="no_items_display">Nothing available to display.</string>
     <string name="ok">OK</string>
-    <string name="parse_error">Sorry, unable to parse form.</string>
     <string name="password">Password</string>
     <string name="play_audio">Play Sound</string>
     <string name="play_video">Play Video</string>
@@ -323,7 +318,6 @@
     <string name="required_answer_error">Sorry, this response is required!</string>
     <string name="review_data">Edit Saved Form</string>
     <string name="save_all_answers">Save Form</string>
-    <string name="save_enter_data_description">You are at the end of the form.</string>
     <string name="saving_form">Saving Form</string>
     <string name="send_data">Send Finalized Form</string>
     <string name="trigger">OK. Please continue.</string>
@@ -331,7 +325,6 @@
     <string name="general_preferences">Settings</string>
     <string name="show_splash">Show splash screen</string>
     <string name="keep_changes">Save Changes</string>
-    <string name="xform_parse_error">XForm parse error. %1$s is missing element %2$s</string>
     <string name="choose_sound">Choose Sound</string>
     <string name="choose_video">Choose Video</string>
     <string name="choose_image">Choose Image</string>
@@ -347,40 +340,27 @@
     <string name="sending_failed_on_date_at_time">\'Sending failed on\' EEE, MMM dd, yyyy \'at\' HH:mm</string> <!-- http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html -->
     <string name="version">Version:</string>
     <string name="launch_app">Launch</string>
-    <string name="no_app">The requested application is missing. Please manually enter the reading.</string>
     <string name="select_one">Select One Answer</string>
     <string name="savepoint_used">Unsaved changes recovered from savepoint!</string>
     <string name="save_and_close">Save and Close</string>
     <string name="sign_button">Gather Signature</string>
-    <string name="markup_image">Markup Image</string>
-    <string name="draw_image">Sketch Image</string>
     <string name="reset_image">Reset</string>
     <string name="set_color">Set Color</string>
     <string name="select_drawing_color">Select Drawing Color</string>
     <string name="user_access_main_menu">User can access Main Menu items:</string>
-    <string name="user_access_preferences">User can access Change Settings items:</string>
     <string name="change_server">Platform</string>
     <string name="change_username_default">Username</string>
-    <string name="admin_access_settings">Tap for admin access to settings</string>
-    <string name="user_access_form_entry">User can access Form Entry items:</string>
     <string name="save_mid">Save Form</string>
     <string name="enter_new_password">Enter new password</string>
     <string name="verify_new_password">Re-enter new password</string>
     <string name="admin_password_changed">Admin password successfully changed</string>
     <string name="admin_password_disabled">Admin password disabled</string>
     <string name="admin_password_mismatch">Sorry, passwords do not match!</string>
-    <string name="found_in_menu">Uncheck to hide from menu in Form Entry</string>
-    <string name="autosend_wifi">Auto send with Wi-Fi</string>
-    <string name="autosend_network">Auto send with network</string>
-    <string name="found_in_main">Uncheck to hide from Main Menu</string>
-    <string name="found_in_settings">Uncheck to hide from General Settings</string>
-    <string name="found_at_end">Uncheck to hide from end of Form Entry</string>
     <string name="form_forward">Next</string>
     <string name="form_backward">Prev</string>
     <string name="change_url_default">URL</string>
     <string name="launch_printer">Initiate Printing</string>
     <string name="no_printer">The requested printer is not installed. Please install the printer.</string>
-    <string name="constraint_behavior">Constraint processing behavior</string>
     <string name="on_switch_label">On</string>
     <string name="off_switch_label">Off</string>
     <string name="send_email_title">Send email...</string>


### PR DESCRIPTION
Marking strings notranslate/locked in Transifex prevents the status of downstream resources from reaching 100% once all other strings are translated.